### PR TITLE
MLFLOW model correction

### DIFF
--- a/core/types.py
+++ b/core/types.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Generic, Optional, TypeVar
+from datetime import datetime
 import numpy as np
 
 TX = TypeVar("TX")  # Type of X (Usually a numpy array or a pandas DataFrame)
@@ -11,6 +12,8 @@ class ProcessedData(Generic[TX]):
     X: Optional[TX] = None
     y: Optional[np.ndarray] = None
     feature_index_map: Optional[dict[str, int]] = None
+    start_date: Optional[datetime.date] = None
+    end_date: Optional[datetime.date] = None
 
 
 # Represents the evaluation metrics expected from a model

--- a/core/utils.py
+++ b/core/utils.py
@@ -179,17 +179,16 @@ def get_start_date_from_trading_days(
     return start_date
 
 
-def get_model_name(model_type: str, symbol: str, phase: str):
+def get_model_name(model_type: str, symbol: str):
     """
     Generate a standardized model name by combining the model type
-    and stock symbol for a given phase (training and prediction).
+    and stock symbol.
 
     Args:
         model_type (str): The model type
         symbol (str): The stock ticker symbol
-        phase (str): The phase of
 
     Returns:
         str: A string representing the model name
     """
-    return f"{model_type}_{symbol}_{phase}"
+    return f"{model_type}_{symbol}"

--- a/services/evaluation_service.py
+++ b/services/evaluation_service.py
@@ -22,7 +22,6 @@ class EvaluationService(BaseService):
 
     async def evaluate(
         self,
-        model_name: str,
         y_true: np.ndarray,
         y_pred: np.ndarray,
     ) -> dict:
@@ -30,7 +29,6 @@ class EvaluationService(BaseService):
         Evaluate the performance of a trained model using predicted and true target values.
 
         Args:
-            model_type (str): Type of the model being evaluated (e.g., 'lstm', 'prophet').
             y_true (np.ndarray): Ground truth target values.
             y_pred (np.ndarray): Predicted target values by the model.
 
@@ -39,14 +37,14 @@ class EvaluationService(BaseService):
         """
 
         try:
-            self.logger.info(f"Starting evaluation for {model_name} model")
+            self.logger.info(f"Starting evaluation")
 
             metrics = self._calculate_metrics(y_true, y_pred)
 
             # Returns the metrics as a dict
             return metrics.__dict__
         except Exception as e:
-            self.logger.error(f"Evaluation failed for {model_name} model: {str(e)}")
+            self.logger.error(f"Evaluation failed: {str(e)}")
             raise
 
     async def should_deploy_model(

--- a/services/orchestration/flows/evaluate_and_log_flow.py
+++ b/services/orchestration/flows/evaluate_and_log_flow.py
@@ -4,18 +4,17 @@ from .tasks import evaluate, log_metrics
 
 @flow(name="Evaluate and logs metrics (Sub-Pipeline)")
 async def run_evaluate_and_log_flow(
-    model_name, true_target, pred_target, evaluation_service, deployment_service
+    model_identifier, true_target, pred_target, evaluation_service, deployment_service
 ):
 
     # Evaluate the model
     metrics = await evaluate(
-        model_name=model_name,
         true_target=true_target.y,
         pred_target=pred_target.y,
         service=evaluation_service,
     )
 
     # Log the metrics
-    await log_metrics(model_name, metrics, deployment_service)
+    await log_metrics(model_identifier, metrics, deployment_service)
 
     return metrics

--- a/services/orchestration/flows/evaluation_flow.py
+++ b/services/orchestration/flows/evaluation_flow.py
@@ -16,7 +16,7 @@ async def run_evaluation_pipeline(
     evaluation_service,
 ):
     # Get the live model name
-    live_model_name = get_model_name(model_type, symbol, "prediction")
+    live_model_name = get_model_name(model_type, symbol)
 
     # Checks if the live model exists
     live_model_exist = await model_exist(live_model_name, deployment_service)
@@ -33,6 +33,7 @@ async def run_evaluation_pipeline(
 
         # Make inference (prediction) using live model
         pred_target, _, _ = await run_inference_pipeline(
+            model_identifier=live_model_name,
             model_type=model_type,
             symbol=symbol,
             phase="prediction",
@@ -52,7 +53,7 @@ async def run_evaluation_pipeline(
 
         # Evaluate the training model
         metrics = await run_evaluate_and_log_flow(
-            model_name=live_model_name,
+            model_identifier=live_model_name,
             true_target=true_target,
             pred_target=pred_target,
             evaluation_service=evaluation_service,

--- a/services/orchestration/flows/inference_flow.py
+++ b/services/orchestration/flows/inference_flow.py
@@ -1,18 +1,22 @@
 from prefect import flow
 from .tasks import predict, postprocess_data, calculate_prediction_confidence
-from core.utils import get_model_name
 import numpy as np
 
 
 @flow(name="Inference Pipeline")
 async def run_inference_pipeline(
-    model_type, symbol, phase, prediction_input, processing_service, deployment_service
+    model_identifier,
+    model_type,
+    symbol,
+    phase,
+    prediction_input,
+    processing_service,
+    deployment_service,
 ):
-    model_name = get_model_name(model_type=model_type, symbol=symbol, phase=phase)
 
     # Prediction
     y_pred, model_version = await predict(
-        model_name=model_name,
+        model_identifier=model_identifier,
         X=prediction_input.X,
         service=deployment_service,
     )

--- a/services/orchestration/flows/prediction_flow.py
+++ b/services/orchestration/flows/prediction_flow.py
@@ -11,9 +11,12 @@ PHASE = "prediction"
 async def run_prediction_pipeline(
     model_type: str, symbol: str, data_service, processing_service, deployment_service
 ):
-    live_model_exist = await model_exist(
-        get_model_name(model_type, symbol, PHASE), deployment_service
-    )
+
+    # Generate the production model (live model) name
+    live_model_name = get_model_name(model_type, symbol)
+
+    # Check if it exist
+    live_model_exist = await model_exist(live_model_name, deployment_service)
     if live_model_exist:
         prediction_input = await run_data_pipeline(
             symbol=symbol,
@@ -25,6 +28,7 @@ async def run_prediction_pipeline(
 
         # Make prediction (prediction and confidence included)
         pred_target, confidence, model_version = await run_inference_pipeline(
+            model_identifier=live_model_name,
             model_type=model_type,
             symbol=symbol,
             phase=PHASE,

--- a/services/orchestration/flows/tasks/deploy.py
+++ b/services/orchestration/flows/tasks/deploy.py
@@ -5,11 +5,11 @@ from services import DeploymentService
 
 @task(retries=3, retry_delay_seconds=5)
 async def promote_model(
-    model_type: str,
-    symbol: str,
+    run_id: str,
+    model_name: str,
     service: DeploymentService,
 ) -> bool:
-    return await service.promote_model(model_type=model_type, symbol=symbol)
+    return await service.promote_model(run_id=run_id, prod_model_name=model_name)
 
 
 @task(retries=3, retry_delay_seconds=2)
@@ -18,8 +18,8 @@ async def model_exist(model_name: str, service: DeploymentService) -> bool:
 
 
 @task(retries=3, retry_delay_seconds=5)
-async def log_metrics(model_name: str, metrics, service: DeploymentService):
-    return await service.log_metrics(model_name=model_name, metrics=metrics)
+async def log_metrics(model_identifier: str, metrics, service: DeploymentService):
+    return await service.log_metrics(model_identifier=model_identifier, metrics=metrics)
 
 
 @task(retries=3, retry_delay_seconds=5)

--- a/services/orchestration/flows/tasks/evaluate.py
+++ b/services/orchestration/flows/tasks/evaluate.py
@@ -4,12 +4,8 @@ from services import EvaluationService
 
 
 @task(retries=2, retry_delay_seconds=5)
-async def evaluate(
-    model_name: str, true_target, pred_target, service: EvaluationService
-):
-    return await service.evaluate(
-        model_name=model_name, y_true=true_target, y_pred=pred_target
-    )
+async def evaluate(true_target, pred_target, service: EvaluationService):
+    return await service.evaluate(y_true=true_target, y_pred=pred_target)
 
 
 @task(retries=2, retry_delay_seconds=5)

--- a/services/orchestration/flows/tasks/predict.py
+++ b/services/orchestration/flows/tasks/predict.py
@@ -4,5 +4,5 @@ from services import DeploymentService
 
 
 @task(retries=3, retry_delay_seconds=5)
-async def predict(model_name: str, X, service: DeploymentService):
-    return await service.predict(model_name, X)
+async def predict(model_identifier: str, X, service: DeploymentService):
+    return await service.predict(model_identifier, X)


### PR DESCRIPTION
À la place d'utiliser deux modèles pour le training et prediction (ex: lstm_AAPL_training, lstm_AAPL_prediction), un seul modèle est utilisé (ex: lstm_AAPL).

Un seul modèle (le production/prediction model) est register dans MLFlow. Les training models sont seulement logger et, peuvent être accéder par leur MLFlow run id.

J'ai aussi ajouter des dates aux ProcessedData data type + ajouter des tags (training_data_start_date et training_data_end_date) au modèles MLFlow pour garder en mémoire les dates des données utilisées pour le training. Cela va être utilise pour le data monitoring