### PR TITLE
use submit/result logic to prevent sqlite errors

### DIFF
--- a/services/orchestration/flows/data_flow.py
+++ b/services/orchestration/flows/data_flow.py
@@ -3,16 +3,19 @@ from .tasks import load_data, preprocess_data
 
 
 @flow(name="Data Pipeline")
-async def run_data_pipeline(
+def run_data_pipeline(
     model_type: str, symbol: str, phase: str, data_service, processing_service
 ):
-    raw_data = await load_data(data_service, symbol)
-    preprocessed_data = await preprocess_data(
+    raw_data_future = load_data.submit(data_service, symbol)
+    raw_data = raw_data_future.result()
+
+    preprocessed_data_future = preprocess_data.submit(
         service=processing_service,
         symbol=symbol,
         data=raw_data,
         model_type=model_type,
         phase=phase,
     )
+    preprocessed_data = preprocessed_data_future.result()
 
     return preprocessed_data

--- a/services/orchestration/flows/evaluate_and_log_flow.py
+++ b/services/orchestration/flows/evaluate_and_log_flow.py
@@ -3,18 +3,21 @@ from .tasks import evaluate, log_metrics
 
 
 @flow(name="Evaluate and logs metrics (Sub-Pipeline)")
-async def run_evaluate_and_log_flow(
+def run_evaluate_and_log_flow(
     model_identifier, true_target, pred_target, evaluation_service, deployment_service
 ):
-
     # Evaluate the model
-    metrics = await evaluate(
+    metrics_future = evaluate.submit(
         true_target=true_target.y,
         pred_target=pred_target.y,
         service=evaluation_service,
     )
 
+    # Wait for it to finish and get result
+    metrics = metrics_future.result()
+
     # Log the metrics
-    await log_metrics(model_identifier, metrics, deployment_service)
+    future = log_metrics.submit(model_identifier, metrics, deployment_service)
+    future.result()
 
     return metrics

--- a/services/orchestration/flows/evaluation_flow.py
+++ b/services/orchestration/flows/evaluation_flow.py
@@ -7,7 +7,7 @@ from core.utils import get_model_name
 
 
 @flow(name="Evaluation Pipeline")
-async def run_evaluation_pipeline(
+def run_evaluation_pipeline(
     model_type: str,
     symbol: str,
     data_service,
@@ -19,11 +19,11 @@ async def run_evaluation_pipeline(
     live_model_name = get_model_name(model_type, symbol)
 
     # Checks if the live model exists
-    live_model_exist = await model_exist(live_model_name, deployment_service)
+    live_model_exist = model_exist.submit(live_model_name, deployment_service)
 
-    if live_model_exist:
+    if live_model_exist.result():
         # Run the data pipeline (Data Ingestion + Preprocessing)
-        eval_data = await run_data_pipeline(
+        eval_data = run_data_pipeline(
             symbol=symbol,
             model_type=model_type,
             data_service=data_service,
@@ -32,7 +32,7 @@ async def run_evaluation_pipeline(
         )
 
         # Make inference (prediction) using live model
-        pred_target, _, _ = await run_inference_pipeline(
+        pred_target, _, _ = run_inference_pipeline(
             model_identifier=live_model_name,
             model_type=model_type,
             symbol=symbol,
@@ -43,16 +43,17 @@ async def run_evaluation_pipeline(
         )
 
         # Unnormalize (unscale) the ground truth values
-        true_target = await postprocess_data(
+        true_target_future = postprocess_data.submit(
             service=processing_service,
             symbol=symbol,
             model_type=model_type,
             phase="prediction",
             prediction=eval_data.y,
         )
+        true_target = true_target_future.result()
 
         # Evaluate the training model
-        metrics = await run_evaluate_and_log_flow(
+        metrics = run_evaluate_and_log_flow(
             model_identifier=live_model_name,
             true_target=true_target,
             pred_target=pred_target,

--- a/services/orchestration/flows/inference_flow.py
+++ b/services/orchestration/flows/inference_flow.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 @flow(name="Inference Pipeline")
-async def run_inference_pipeline(
+def run_inference_pipeline(
     model_identifier,
     model_type,
     symbol,
@@ -15,13 +15,14 @@ async def run_inference_pipeline(
 ):
 
     # Prediction
-    y_pred, model_version = await predict(
+    predict_future = predict.submit(
         model_identifier=model_identifier,
         X=prediction_input.X,
         service=deployment_service,
     )
+    y_pred, model_version = predict_future.result()
 
-    processed_y_pred = await postprocess_data(
+    processed_y_pred_future = postprocess_data.submit(
         service=processing_service,
         symbol=symbol,
         prediction=y_pred,
@@ -31,14 +32,17 @@ async def run_inference_pipeline(
 
     # Calculate prediction confidence (if the phase is prediction else None)
     confidence = (
-        await calculate_prediction_confidence(
+        calculate_prediction_confidence.submit(
             model_type=model_type,
             y_pred=y_pred,
             prediction_input=prediction_input,
             service=deployment_service,
-        )
+        ).result()
         if phase == "prediction"
         else None
     )
+
+    # Wait for results
+    processed_y_pred = processed_y_pred_future.result()
 
     return processed_y_pred, confidence, model_version

--- a/services/orchestration/flows/prediction_flow.py
+++ b/services/orchestration/flows/prediction_flow.py
@@ -8,7 +8,7 @@ PHASE = "prediction"
 
 
 @flow(name="Prediction Pipeline", retries=2, retry_delay_seconds=10)
-async def run_prediction_pipeline(
+def run_prediction_pipeline(
     model_type: str, symbol: str, data_service, processing_service, deployment_service
 ):
 
@@ -16,9 +16,10 @@ async def run_prediction_pipeline(
     live_model_name = get_model_name(model_type, symbol)
 
     # Check if it exist
-    live_model_exist = await model_exist(live_model_name, deployment_service)
-    if live_model_exist:
-        prediction_input = await run_data_pipeline(
+    live_model_exist = model_exist.submit(live_model_name, deployment_service)
+
+    if live_model_exist.result():
+        prediction_input = run_data_pipeline(
             symbol=symbol,
             model_type=model_type,
             data_service=data_service,
@@ -27,7 +28,7 @@ async def run_prediction_pipeline(
         )
 
         # Make prediction (prediction and confidence included)
-        pred_target, confidence, model_version = await run_inference_pipeline(
+        pred_target, confidence, model_version = run_inference_pipeline(
             model_identifier=live_model_name,
             model_type=model_type,
             symbol=symbol,

--- a/services/orchestration/flows/tasks/deploy.py
+++ b/services/orchestration/flows/tasks/deploy.py
@@ -17,7 +17,7 @@ async def model_exist(model_name: str, service: DeploymentService) -> bool:
     return await service.model_exists(model_name)
 
 
-@task(retries=3, retry_delay_seconds=5)
+@task(retries=3, retry_delay_seconds=5, timeout_seconds=30)
 async def log_metrics(model_identifier: str, metrics, service: DeploymentService):
     return await service.log_metrics(model_identifier=model_identifier, metrics=metrics)
 

--- a/services/orchestration/orchestration_service.py
+++ b/services/orchestration/orchestration_service.py
@@ -64,7 +64,7 @@ class OrchestrationService(BaseService):
             )
 
             # Run the training pipeline
-            result = await run_training_pipeline(
+            result = run_training_pipeline(
                 model_type,
                 symbol,
                 self.data_service,
@@ -114,7 +114,7 @@ class OrchestrationService(BaseService):
             )
 
             # Run the prediction pipeline
-            prediction_result = await run_prediction_pipeline(
+            prediction_result = run_prediction_pipeline(
                 model_type,
                 symbol,
                 self.data_service,
@@ -185,7 +185,7 @@ class OrchestrationService(BaseService):
             )
 
             # Run the evaluation pipeline
-            result = await run_evaluation_pipeline(
+            result = run_evaluation_pipeline(
                 model_type,
                 symbol,
                 self.data_service,


### PR DESCRIPTION
Almost fixes #30 

J'ai remplacer la logique await/async avec submit/result pour éviter le plus possible les erreurs avec sqlite.

La meilleure solution serait d'utiliser une autre base de données (ex: Postgres), mais on pourrait faire ça dans la version microservices