### PR TITLE
Scaler registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ data/stock/
 # Ignore MlFlow files
 mlruns/
 
+# Ignore Scaler data infos (registry)
+data_processing/scalers/scaler_registry.json
+
 stock-ai.code-workspace
 
 # Ignore Grafana DB and plugins

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -82,7 +82,7 @@ class TrainingResponse(BaseModel):
     model_type: str
     training_results: Dict[str, Any]
     metrics: Dict[str, float]
-    deployment_results: Dict[str, Any] = None
+    deployment_results: Optional[Dict[str, Any]] = None
     timestamp: str
 
 

--- a/core/config.py
+++ b/core/config.py
@@ -22,7 +22,8 @@ class DataConfig(BaseModel):
 class PreprocessingConfig(BaseModel):
     """Preprocessing service configuration"""
 
-    SCALERS_DIR: Path = Path("scalers")
+    SCALERS_DIR: Path = Path("data_processing/scalers")
+    SCALER_REGISTRY_JSON: Path = SCALERS_DIR / "scaler_registry.json"
     TRAINING_SPLIT_RATIO: float = 0.8
     SEQUENCE_LENGTH: int = 60
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -63,7 +63,7 @@ def format_prediction_response(
     return {
         "status": "success",
         "symbol": symbol,
-        "date": date or (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d"),
+        "date": get_next_trading_day().strftime("%Y-%m-%d"),
         "predicted_price": safe_float(prediction),
         "confidence": safe_float(confidence),
         "model_type": model_type,
@@ -125,7 +125,7 @@ def get_latest_trading_day():
     return datetime.combine(latest_trading_day, datetime.min.time())
 
 
-def get_next_trading_day():
+def get_next_trading_day() -> datetime:
     """
     Get the next valid trading day
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # ML specific requirements
 torch>=2.0.1
 keras>=3.0.0
-transformers>=4.30.2
+transformers==4.53.1
 numpy<2.0.0  # Pin to 1.x for compatibility
 pandas>=1.3.0
 scikit-learn>=0.24.2

--- a/services/data_processing/scaler_manager.py
+++ b/services/data_processing/scaler_manager.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import joblib
+import json
 from sklearn.preprocessing import MinMaxScaler
-import shutil
 
 from core.config import config
 
@@ -21,13 +21,24 @@ class ScalerFactory:
 
 
 class ScalerManager:
+
+    # Path to the scaler registry (JSON file)
+    REGISTRY_PATH = config.preprocessing.SCALER_REGISTRY_JSON
+
+    # Scaler types
     FEATURES_SCALER_TYPE = "features"
     TARGETS_SCALER_TYPE = "targets"
     VALID_SCALER_TYPES = {FEATURES_SCALER_TYPE, TARGETS_SCALER_TYPE}
 
+    # Phases
+    TRAINING_PHASE = "training"
+    PREDICTION_PHASE = "prediction"
+    VALID_PHASES = [PREDICTION_PHASE, TRAINING_PHASE]
+
     def __init__(self, model_type: str, symbol: str):
         self.model_type = model_type
         self.symbol = symbol
+        self.registry = self._load_registry()
 
     def model_requires_scaling(self) -> bool:
         return ScalerFactory.model_requires_scaling(self.model_type)
@@ -35,37 +46,95 @@ class ScalerManager:
     def create_scaler(self) -> MinMaxScaler:
         return ScalerFactory.create_scaler(self.model_type)
 
-    def save_scaler(self, scaler, phase, scaler_type: str):
+    def save_scaler(self, scaler, scaler_type: str, scaler_dates: tuple[str, str]):
         """
         Save the given scaler to disk.
 
         Args:
             scaler: A fitted scikit-learn scaler to be saved.
-            scaler_type: The type of scaler. Must be one of 'features' or 'targets'.
+            scaler_type (str): The type of scaler. Must be one of 'features' or 'targets'.
+            scaler_dates tuple[str,str]: Start and end dates used in the fitting of the scaler.
         """
         try:
-            joblib.dump(scaler, self.get_scaler_path(phase, scaler_type))
+            if not scaler_dates:
+                raise ValueError("You must provide scaler_dates when saving a scaler.")
+
+            # Get the save path of the scaler
+            save_path = self.get_scaler_path(
+                scaler_type=scaler_type, scaler_dates=scaler_dates
+            )
+
+            # Save the sacler
+            joblib.dump(scaler, save_path)
+
+            # Retrieves the entry to the scaler root path in the registry
+            scaler_root_path = (
+                self.registry.setdefault(self.model_type, {})
+                .setdefault(self.symbol, {})
+                .setdefault(scaler_type, {})
+            )
+
+            # Generate the date identifier (key)
+            key = self._generate_date_identifier(scaler_dates=scaler_dates)
+
+            # Add the save path to the scaler registry (history)
+            scaler_root_path.setdefault("history", {})[key] = str(save_path)
+
+            # Update the training pointer of the registry with the saved path
+            scaler_root_path["training"] = str(save_path)
+
+            # Save the registry
+            self._save_registry()
         except Exception as e:
             raise e
 
     def load_scaler(
-        self, phase: str, scaler_type: str = FEATURES_SCALER_TYPE
+        self,
+        scaler_type: str,
+        phase: str = PREDICTION_PHASE,
+        scaler_dates: tuple[str, str] = None,
     ) -> MinMaxScaler:
         """
-        Load the saved scaler from disk given the model_type and the symbol
+        Load a saved scaler from disk using the registry based on provided parameters.
+
+        If `scaler_dates` is provided, the method will look up the scaler in the historical registry
+        using the specified date range. Otherwise, it will look it up based on the current phase
+        (e.g. 'training' or 'prediction').
 
         Args:
             scaler_type: The type of scaler. Must be one of 'features' or 'targets'.
                 This determines whether the scaler is for input features or the targets variable.
+            phase (str, optional): The data processing phase. Defaults to PREDICTION_PHASE.
+                Must be one of the valid phases defined in `self.VALID_PHASES`. Ignored if `scaler_dates` is provided.
+            scaler_dates (tuple[str, str], optional): Tuple of (start_date, end_date).
+                If provided, loads a historical scaler for the specific date range.
 
         Returns:
             Any (sklearn scalers): The loaded scaler instance.
         """
-        scaler_path = self.get_scaler_path(phase, scaler_type)
+        if not scaler_dates:
+
+            if phase not in self.VALID_PHASES:
+                raise ValueError(
+                    f"Invalid phase '{phase}'. Must be one of {self.VALID_PHASES}."
+                )
+
+            scaler_path = self.registry[self.model_type][self.symbol][scaler_type][
+                phase
+            ]
+
+        else:
+            date_identifier = self._generate_date_identifier(scaler_dates=scaler_dates)
+            scaler_path = self.registry[self.model_type][self.symbol][scaler_type][
+                "history"
+            ][date_identifier]
+
+        # Turn the string path to a Path
+        scaler_path = Path(scaler_path)
 
         if not scaler_path.exists:
             raise FileNotFoundError(
-                f"Scaler not found for model {self.model_type} for symbol {self.symbol} for {phase} phase"
+                f"Scaler not found for model {self.model_type} for symbol {self.symbol} for the date range {scaler_dates} phase"
             )
 
         return joblib.load(scaler_path)
@@ -80,30 +149,36 @@ class ScalerManager:
         try:
             if self.model_requires_scaling():
 
-                # Get the training scalers
-                src_features_scaler_path = self.get_scaler_path(
-                    "training", self.FEATURES_SCALER_TYPE
-                )
-                src_targets_scaler_path = self.get_scaler_path(
-                    "training", self.TARGETS_SCALER_TYPE
+                # Targets scaler path to promote
+                targets_scaler_path_to_promote = Path(
+                    self.registry[self.model_type][self.symbol][
+                        self.TARGETS_SCALER_TYPE
+                    ][self.TRAINING_PHASE]
                 )
 
-                dst_features_scaler_path = self.get_scaler_path(
-                    "prediction", self.FEATURES_SCALER_TYPE
-                )
-                dst_targets_scaler_path = self.get_scaler_path(
-                    "prediction", self.TARGETS_SCALER_TYPE
+                # Features scaler path to promote
+                features_scaler_path_to_promote = Path(
+                    self.registry[self.model_type][self.symbol][
+                        self.FEATURES_SCALER_TYPE
+                    ][self.TRAINING_PHASE]
                 )
 
                 if (
-                    not src_features_scaler_path.exists()
-                    or not src_targets_scaler_path.exists()
+                    not features_scaler_path_to_promote.exists()
+                    or not targets_scaler_path_to_promote.exists()
                 ):
                     raise FileNotFoundError(f"Missing scaler to promote")
 
-                # Copy the training scalers to prediction scalers
-                shutil.copyfile(src_features_scaler_path, dst_features_scaler_path)
-                shutil.copyfile(src_targets_scaler_path, dst_targets_scaler_path)
+                # Set the 'prediction' pointers for target and features
+                self._set_prediction_scaler_path(
+                    self.FEATURES_SCALER_TYPE, features_scaler_path_to_promote
+                )
+                self._set_prediction_scaler_path(
+                    self.TARGETS_SCALER_TYPE, targets_scaler_path_to_promote
+                )
+
+                # Save the registry updates
+                self._save_registry()
 
                 return True
             else:
@@ -111,16 +186,15 @@ class ScalerManager:
         except Exception as e:
             raise RuntimeError("Error while promoting the scalers") from e
 
-    def get_scaler_path(
-        self, phase: str, scaler_type: str = FEATURES_SCALER_TYPE
-    ) -> Path:
+    def get_scaler_path(self, scaler_type: str, scaler_dates: tuple[str, str]) -> Path:
         """
-        Returns the full path to the scaler file based on model type, symbol, and phase.
+        Returns the full path to the scaler file based on model type, symbol, and scaler dates.
         Creates the directory if it doesn't exist.
 
         Args:
             scaler_type: The type of scaler. Must be one of 'features' or 'targets'.
                 This determines whether the scaler is for input features or the targets variable.
+            scaler_dates (tuple[str, str]): Tuple of (start_date, end_date). Dates used to fit the scaler
 
         Returns:
             Path: Path to the scaler file.
@@ -128,16 +202,36 @@ class ScalerManager:
 
         self._validate_scaler_type(scaler_type)
 
+        # Generate the date identifier (used in the scaler filename)
+        date_identifier = self._generate_date_identifier(scaler_dates=scaler_dates)
+
         # Directory of the scaler
         scaler_dir = (
-            config.preprocessing.SCALERS_DIR / self.model_type / phase / self.symbol
+            config.preprocessing.SCALERS_DIR
+            / self.model_type
+            / self.symbol
+            / date_identifier
+            / scaler_type
         )
         scaler_dir.mkdir(parents=True, exist_ok=True)
 
         # Full scaler path (with the corresponding phase)
-        scaler_path = scaler_dir / f"{scaler_type}_scaler.gz"
+        scaler_path = scaler_dir / "scaler.gz"
 
         return scaler_path
+
+    def _load_registry(self):
+        """Load the json registry"""
+        if not self.REGISTRY_PATH.exists():
+            return {}
+        with open(self.REGISTRY_PATH, "r") as f:
+            return json.load(f)
+
+    def _save_registry(self):
+        """Save the registry to local disk"""
+        self.REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.REGISTRY_PATH, "w") as f:
+            json.dump(self.registry, f, indent=4)
 
     def _validate_scaler_type(self, scaler_type: str):
         """
@@ -151,3 +245,30 @@ class ScalerManager:
             raise ValueError(
                 f"Invalid scaler_type '{scaler_type}'. Must be one of {self.VALID_SCALER_TYPES}"
             )
+
+    def _set_prediction_scaler_path(self, scaler_type: str, path: Path):
+        """
+        Set the prediction scaler path (main scaler used in Production)
+
+        Args:
+            scaler_type (str): The type of scaler. Must be one of 'features' or 'targets'.
+                This determines whether the scaler is for input features or the targets variable.
+            path (Path): Path to set
+        """
+        self.registry.setdefault(self.model_type, {}).setdefault(
+            self.symbol, {}
+        ).setdefault(scaler_type, {})["prediction"] = str(path)
+
+    def _generate_date_identifier(self, scaler_dates: tuple[str, str]) -> str:
+        """
+        Generate a date identifier used in the registry and filename of a saved scaler
+
+        Args:
+            scaler_dates (tuple[str, str]): Tuple of (start_date, end_date). Dates used to fit the scaler
+        """
+
+        start_date = scaler_dates[0]
+        end_date = scaler_dates[1]
+        date_identifier = f"{start_date}_{end_date}"
+
+        return date_identifier

--- a/services/deployment/deployment_service.py
+++ b/services/deployment/deployment_service.py
@@ -46,8 +46,22 @@ class DeploymentService(BaseService):
             bool: True if the production model exists, False otherwise.
         """
         try:
-            models = await self.list_models()
-            return prod_model_name in models
+            self.logger.info(
+                f"Checking if the prodcution model '{prod_model_name}' exists."
+            )
+            # Get all the list of the registred (production) models corresponding to the production model name
+            prod_models = await self.mlflow_model_manager.find_registred_model(
+                prod_model_name
+            )
+
+            if prod_models:
+                self.logger.info(f"Prodcution model '{prod_model_name}' exists.")
+                return True
+            else:
+                self.logger.info(
+                    f"Prodcution model '{prod_model_name}' does not exists."
+                )
+                return False
         except Exception as e:
             self.logger.error(
                 f"Failed to check if {prod_model_name} production model exists: {str(e)}"

--- a/services/deployment/mlflow_model_manager.py
+++ b/services/deployment/mlflow_model_manager.py
@@ -20,6 +20,22 @@ class MLflowModelManager:
         except Exception as e:
             raise RuntimeError(f"Error listing the models: {str(e)}") from e
 
+    async def find_registred_model(self, prod_model_name: str) -> list:
+        """
+        Find if a production model exists
+
+        Args:
+            prod_model_name (str): Production model name to check
+        """
+        try:
+            models = self.client.search_registered_models(
+                filter_string=f"name='{prod_model_name}'"
+            )
+
+            return models
+        except Exception as e:
+            raise RuntimeError(f"Error listing the models: {str(e)}") from e
+
     async def load_model(self, model_identifier: str):
         """
         Load the latest MLflow model

--- a/services/orchestration/tasks/data/preprocess.py
+++ b/services/orchestration/tasks/data/preprocess.py
@@ -1,5 +1,6 @@
 from prefect import task
 import pandas as pd
+from typing import Union
 
 from services.data_processing import DataProcessingService
 from core.types import ProcessedData
@@ -17,7 +18,7 @@ async def preprocess_data(
     data: pd.DataFrame,
     model_type: str,
     phase: str,
-) -> ProcessedData:
+) -> Union[ProcessedData, tuple[ProcessedData, ProcessedData]]:
     """
     Prefect task to preprocess raw stock data for model consumption.
 


### PR DESCRIPTION
Fixes #52 

Les scalers sont maintenant gérés par un scaler registry (fichier .json cré. lorsqu'un /train est éxécuté).

Ce registry permet de map les bons scalers aux bons modèles (training vs prod) .

Il y a aussi de petites corrections qui ont été apportées (commentaires, fix une version d'un requirement, etc.)