### PR TITLE
Prefect server + time execution optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ data/stock/
 # Ignore MlFlow files
 mlruns/
 
+# Ignore Prefect files
+prefect_data/
+
 # Ignore Scaler data infos (registry)
 data_processing/scalers/scaler_registry.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ mlruns/
 prefect_data/
 
 # Ignore Scaler data infos (registry)
-data_processing/scalers/scaler_registry.json
+data/scalers/scaler_registry.json
 
 stock-ai.code-workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ ENV PYTHONPATH=/app \
     HF_HUB_OFFLINE=0 \
     HF_HUB_DISABLE_TELEMETRY=1 \
     #Sets PyTorch as the Keras backend
-    KERAS_BACKEND="torch" 
+    KERAS_BACKEND="torch" \
+    GIT_PYTHON_REFRESH="quiet"
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \

--- a/api/routes.py
+++ b/api/routes.py
@@ -77,7 +77,7 @@ async def health_check():
             news_service,
             training_service,
             data_service,
-            preprocessing_service,
+            data_processing_service,
             evaluation_service,
         )
 
@@ -86,7 +86,7 @@ async def health_check():
         news_health = await news_service.health_check()
         training_health = await training_service.health_check()
         data_health = await data_service.health_check()
-        preprocessing_health = await preprocessing_service.health_check()
+        preprocessing_health = await data_processing_service.health_check()
         evaluation_health = await evaluation_service.health_check()
 
         # Create response with boolean values

--- a/core/config.py
+++ b/core/config.py
@@ -11,6 +11,7 @@ class DataConfig(BaseModel):
     """Data collection and storage configuration."""
 
     STOCK_DATA_DIR: Path = Path("data/stock")
+    PREDICT_DATA_DIR: Path = Path("data/predictions")
     NEWS_DATA_DIR: Path = Path("data/news")
     LOGS_DIR: Path = Path("logs")
     LOOKBACK_PERIOD_DAYS: int = 365

--- a/core/config.py
+++ b/core/config.py
@@ -23,7 +23,7 @@ class DataConfig(BaseModel):
 class PreprocessingConfig(BaseModel):
     """Preprocessing service configuration"""
 
-    SCALERS_DIR: Path = Path("data_processing/scalers")
+    SCALERS_DIR: Path = Path("data/scalers")
     SCALER_REGISTRY_JSON: Path = SCALERS_DIR / "scaler_registry.json"
     TRAINING_SPLIT_RATIO: float = 0.8
     SEQUENCE_LENGTH: int = 60

--- a/core/logging.py
+++ b/core/logging.py
@@ -25,7 +25,7 @@ console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setFormatter(formatter)
 
 # Create file handler
-file_handler = logging.FileHandler("stock-ai.log")
+file_handler = logging.FileHandler("stock-ai.log", encoding="utf-8")
 file_handler.setFormatter(formatter)
 
 # Configure root logger
@@ -48,11 +48,12 @@ loggers: Dict[str, logging.Logger] = {
     "training": logging.getLogger("training"),
     "orchestration": logging.getLogger("orchestration"),
     "news": logging.getLogger("news"),
+    "visualization": logging.getLogger("visualization"),
 }
 
 # Configure each logger
 for name, logger in loggers.items():
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG)
     logger.addHandler(console_handler)
     logger.addHandler(file_handler)
     logger.propagate = False  # Prevent messages from being handled by root logger

--- a/core/utils.py
+++ b/core/utils.py
@@ -63,7 +63,7 @@ def format_prediction_response(
     return {
         "status": "success",
         "symbol": symbol,
-        "date": get_next_trading_day().strftime("%Y-%m-%d"),
+        "date": get_next_trading_day(date).strftime("%Y-%m-%d"),
         "predicted_price": safe_float(prediction),
         "confidence": safe_float(confidence),
         "model_type": model_type,
@@ -125,22 +125,28 @@ def get_latest_trading_day():
     return datetime.combine(latest_trading_day, datetime.min.time())
 
 
-def get_next_trading_day() -> datetime:
+def get_next_trading_day(date: datetime = None) -> datetime:
     """
-    Get the next valid trading day
+    Get the next valid trading day with the provided date
+
+    Args:
+        date (datetime): Provided date to look for next trading day
 
     Returns:
         str: the next valid trading day (in string format)
     """
     nyse = mcal.get_calendar("NYSE")
-    today = datetime.now()
 
-    # Get the next few trading days (starting tomorrow)
+    if date is None:
+        # If there is no provided date, we look for next trading day from today
+        date = datetime.now()
+
+    # Get the next few trading days (starting the day after the provided date)
     schedule = nyse.schedule(
-        start_date=today + timedelta(days=1), end_date=today + timedelta(days=10)
+        start_date=date + timedelta(days=1), end_date=date + timedelta(days=10)
     )
 
-    # Return the first valid trading day after today
+    # Return the first valid trading day after the provided date
     return schedule.index[0].to_pydatetime()
 
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -35,8 +35,8 @@ def format_prediction_response(
     confidence: float,
     model_type: str,
     model_version: str,
-    symbol: str = None,
-    date: str = None,
+    symbol: str,
+    date: str,
 ) -> Dict[str, Any]:
     """
     Format prediction response.
@@ -63,7 +63,7 @@ def format_prediction_response(
     return {
         "status": "success",
         "symbol": symbol,
-        "date": get_next_trading_day(date).strftime("%Y-%m-%d"),
+        "date": date.strftime("%Y-%m-%d"),
         "predicted_price": safe_float(prediction),
         "confidence": safe_float(confidence),
         "model_type": model_type,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,15 @@
 services:
+  prefect-server:
+    image: prefecthq/prefect:3-latest
+    container_name: prefect-server
+    command: prefect server start --host 0.0.0.0
+    ports:
+      - "4200:4200"
+    volumes:
+      - ./prefect_data:/root/.prefect
+    networks:
+      - microservices_auth
+
   stock-ai:
     build:
       context: .
@@ -7,13 +18,13 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - .:/app                 
-      - /app/__pycache__        
-      - ./logs:/app/logs       
-      - ./data:/app/data       
-      - ./models:/app/models   
-      - ./mlruns:/app/mlruns   
-      - ./scalers:/app/scalers 
+      - .:/app
+      - /app/__pycache__
+      - ./logs:/app/logs
+      - ./data:/app/data
+      - ./models:/app/models
+      - ./mlruns:/app/mlruns
+      - ./scalers:/app/scalers
     environment:
       - RABBITMQ_HOST=rabbitmq
       - RABBITMQ_PORT=5672
@@ -21,6 +32,7 @@ services:
       - RABBITMQ_PASS=guest
       - API_HOST=0.0.0.0
       - API_PORT=8000
+      - PREFECT_API_URL=http://prefect-server:4200/api
     networks:
       - microservices_auth
     restart: on-failure:3
@@ -30,6 +42,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 5s
+    depends_on:
+      - prefect-server
 
   monitor:
     build:

--- a/main.py
+++ b/main.py
@@ -42,26 +42,26 @@ from services.orchestration import OrchestrationService
 
 # Create service instances in dependency order
 data_service = DataService()
-preprocessing_service = DataProcessingService()
+data_processing_service = DataProcessingService()
 training_service = TrainingService()
 news_service = NewsService()
 deployment_service = DeploymentService()
 evaluation_service = EvaluationService()
 orchestation_service = OrchestrationService(
     data_service=data_service,
-    preprocessing_service=preprocessing_service,
+    data_processing_service=data_processing_service,
     training_service=training_service,
     deployment_service=deployment_service,
     evaluation_service=evaluation_service,
 )
 rabbitmq_service = RabbitMQService()
 monitoring_service = MonitoringService(
-    deployment_service, 
-    orchestation_service, 
+    deployment_service,
+    orchestation_service,
     data_service,
-    preprocessing_service,
-    check_interval_seconds=24*60*60, # 86400 sec in a day
-    data_interval_seconds=7*24*60*60,
+    data_processing_service,
+    check_interval_seconds=24 * 60 * 60,  # 86400 sec in a day
+    data_interval_seconds=7 * 24 * 60 * 60,
 )
 
 
@@ -75,13 +75,13 @@ async def lifespan(app: FastAPI):
         # Initialize services in order of dependencies
         await data_service.initialize()
         await news_service.initialize()
-        await preprocessing_service.initialize()
+        await data_processing_service.initialize()
         await training_service.initialize()
         await deployment_service.initialize()
         await evaluation_service.initialize()
         await orchestation_service.initialize()
         await monitoring_service.initialize()
-        
+
         # Start auto-publishing predictions
         # await prediction_service.start_auto_publishing(interval_minutes=15) # TDOO
 
@@ -102,7 +102,7 @@ async def lifespan(app: FastAPI):
             await deployment_service.cleanup()
             await orchestation_service.cleanup()
             await evaluation_service.cleanup()
-            await preprocessing_service.cleanup()
+            await data_processing_service.cleanup()
             await training_service.cleanup()
             await news_service.cleanup()
             await data_service.cleanup()

--- a/services/data_processing/data_processing_service.py
+++ b/services/data_processing/data_processing_service.py
@@ -206,12 +206,12 @@ class DataProcessingService(BaseService):
         )
 
         # Retrieve training dataset start and end dates
-        train_start_date = dates[0]
-        train_end_date = dates[len(train_data.X) - 1]
+        train_start_date = dates.iloc[0]
+        train_end_date = dates.iloc[len(train_data.X) - 1]
 
         # Retrieve test dataset start and end dates
-        test_start_date = dates[len(train_data.X)]
-        test_end_date = dates[len(dates) - 1]
+        test_start_date = dates.iloc[len(train_data.X)]
+        test_end_date = dates.iloc[len(dates) - 1]
 
         # Normalize the training data
         norm_train_data = DataNormalizer(symbol=symbol, model_type=model_type).process(
@@ -265,8 +265,8 @@ class DataProcessingService(BaseService):
         )
 
         # Retrieve the start and end dates
-        eval_start_date = dates[len(dates) - len(norm_eval_data.X)]
-        eval_end_date = dates[len(dates) - 1]
+        eval_start_date = dates.iloc[len(dates) - len(norm_eval_data.X)]
+        eval_end_date = dates.iloc[len(dates) - 1]
 
         # Add start and end dates to preprocessed data
         norm_eval_data.start_date = eval_start_date
@@ -293,8 +293,8 @@ class DataProcessingService(BaseService):
         )
 
         # Retrieve the start and end dates
-        pred_start_date = dates[len(dates) - len(norm_features.X)]
-        pred_end_date = dates[len(dates) - 1]
+        pred_start_date = dates.iloc[len(dates) - len(norm_features.X)]
+        pred_end_date = dates.iloc[len(dates) - 1]
 
         # Add start and end dates to preprocessed data
         norm_features.start_date = pred_start_date

--- a/services/deployment/deployment_service.py
+++ b/services/deployment/deployment_service.py
@@ -50,11 +50,9 @@ class DeploymentService(BaseService):
                 f"Checking if the prodcution model '{prod_model_name}' exists."
             )
             # Get all the list of the registred (production) models corresponding to the production model name
-            prod_models = await self.mlflow_model_manager.find_registred_model(
-                prod_model_name
-            )
+            prod_model = self.mlflow_model_manager.find_registred_model(prod_model_name)
 
-            if prod_models:
+            if prod_model:
                 self.logger.info(f"Prodcution model '{prod_model_name}' exists.")
                 return True
             else:

--- a/services/deployment/mlflow_model_manager.py
+++ b/services/deployment/mlflow_model_manager.py
@@ -85,7 +85,7 @@ class MLflowModelManager:
                 f"Error retrieving metadata for model '{model_name}': {str(e)}"
             ) from e
 
-    async def find_registred_model(self, prod_model_name: str) -> list:
+    def find_registred_model(self, prod_model_name: str) -> list:
         """
         Find if a registered model exists by name.
 

--- a/services/deployment/mlflow_model_manager.py
+++ b/services/deployment/mlflow_model_manager.py
@@ -118,13 +118,11 @@ class MLflowModelManager:
         """
         try:
             if model_identifier not in self.models_cache:
-
+                version = None
+                
                 if self._run_exists(model_identifier):
                     # Path to the logged trained model
                     model_uri = f"runs:/{model_identifier}/model"
-
-                    # There is no model version for a logged model
-                    version = None
                 else:
                     # Path to the production model (live model)
                     model_uri = f"models:/{model_identifier}@{self.PRODUCTION_ALIAS}"

--- a/services/orchestration/flows/__init__.py
+++ b/services/orchestration/flows/__init__.py
@@ -1,3 +1,7 @@
 from .evaluation_flow import run_evaluation_flow
-from .prediction_flow import run_prediction_flow, run_batch_prediction
+from .prediction_flow import (
+    run_prediction_flow,
+    run_batch_prediction,
+    run_historical_predictions_flow,
+)
 from .training_flow import run_training_flow

--- a/services/orchestration/flows/prediction_flow.py
+++ b/services/orchestration/flows/prediction_flow.py
@@ -2,13 +2,21 @@ from prefect import flow, task
 from prefect.futures import wait
 from itertools import product
 from typing import Any
+from datetime import datetime, timedelta
+import pandas_market_calendars as mcal
 
 from ..tasks.prediction import predict, calculate_prediction_confidence
-from ..tasks.data import load_recent_stock_data, postprocess_data, preprocess_data
+from ..tasks.data import (
+    load_recent_stock_data,
+    postprocess_data,
+    preprocess_data,
+    load_historical_stock_prices_from_end_date,
+)
 from ..tasks.deployment import production_model_exists
 from core.utils import get_model_name
 from services import DataService, DataProcessingService, DeploymentService
 from core.types import ProcessedData
+from core.config import config
 
 PHASE = "prediction"
 
@@ -254,3 +262,139 @@ def run_batch_prediction(
 
     # Wait for all predictions to complete
     wait(predictions)
+
+
+@task(
+    name="Historical Predictions Pipeline Task",
+    description="Runs a prediction pipeline for a given symbol and date, using a deployed production model.",
+)
+def historical_prediction(
+    model_type: str,
+    symbol: str,
+    end_date: datetime,
+    data_service: DataService,
+    processing_service: DataProcessingService,
+    deployment_service: DeploymentService,
+) -> dict[str, Any]:
+    """
+    Run a historical prediction for a given stock symbol and date.
+
+    Args:
+        model_type (str): The type of model (e.g., "lstm", "prophet").
+        symbol (str): Stock ticker sym
+        end_date (datetime): The day before the day to predict
+        data_service (DataService): Service to retrieve stock data.
+        processing_service (DataProcessingService): Service to preprocess ata.
+        deployment_service (DeploymentService): Deployment service
+
+    Returns:
+        dict: A dictionary containing the prediction results:
+            - processed_y_pred (Any): Postprocessed prediction object.
+            - confidence (float or None): Optional prediction confidence score.
+            - model_version (int): Version number of the model that made the prediction.
+    """
+
+    # Load the raw historical data
+    raw_data = load_historical_stock_prices_from_end_date.submit(
+        service=data_service,
+        symbol=symbol,
+        end_date=end_date,
+        days_back=config.preprocessing.SEQUENCE_LENGTH,
+    )
+
+    # Preprocess the raw data
+    prediction_input = preprocess_data.submit(
+        model_type=model_type,
+        symbol=symbol,
+        data=raw_data,
+        service=processing_service,
+        phase=PHASE,
+    )
+
+    # Generate the production model name
+    production_model_name = get_model_name(model_type, symbol)
+
+    # Make prediction (prediction and confidence included)
+    prediction_result = run_inference_flow(
+        model_identifier=production_model_name,
+        model_type=model_type,
+        symbol=symbol,
+        phase=PHASE,
+        prediction_input=prediction_input,
+        processing_service=processing_service,
+        deployment_service=deployment_service,
+    )
+
+    return {
+        "y_pred": prediction_result["prediction"].y,
+        "confidence": prediction_result["confidence"],
+        "model_version": prediction_result["model_version"],
+    }
+
+
+@flow(
+    name="Historical Predictions Pipeline",
+    description="Runs predictions for dates in a date ranges (start_date and end_date)",
+)
+def run_historical_predictions_flow(
+    model_type: str,
+    symbol: str,
+    start_date: datetime,
+    end_date: datetime,
+    data_service: DataService,
+    processing_service: DataProcessingService,
+    deployment_service: DeploymentService,
+):
+    """
+    Run historical predictions for a given symbol and date range using a production model.
+
+    Args:
+        model_type (str): The type of model (e.g., "lstm", "prophet").
+        symbol (str): Stock ticker symbol
+        start_date (datetime): The start of the historical date range.
+        end_date (datetime): The end of the historical date range.
+        data_service (DataService): Service to retrieve stock data.
+        processing_service (DataProcessingService): Service to preprocess ata.
+        deployment_service (DeploymentService): Deployment service.
+
+    Returns:
+        dict|None: A dictionary containing:
+            - "dates": List of trading dates used for prediction.
+            - "predictions": List of prediction results corresponding to those dates.
+        Returns None if no production model is available.
+    """
+    # Generate the production model name
+    production_model_name = get_model_name(model_type, symbol)
+
+    # Check if it exist
+    prod_model_exist = production_model_exists.submit(
+        production_model_name, deployment_service
+    ).result()
+
+    if prod_model_exist:
+
+        # Generate the list of dates (only keep valid trading days)
+        nyse = mcal.get_calendar("NYSE")
+        schedule = nyse.schedule(start_date=start_date, end_date=end_date)
+        trading_days = schedule.index.to_pydatetime().tolist()
+
+        # Shift all the dates by minus 1
+        dates = [d - timedelta(days=1) for d in trading_days]
+
+        # Make predictions
+        prediction_futures = historical_prediction.map(
+            model_type=model_type,
+            symbol=symbol,
+            end_date=dates,
+            data_service=data_service,
+            processing_service=processing_service,
+            deployment_service=deployment_service,
+        )
+
+        # Wait for predictions and collect results
+        prediction_results = [future.result() for future in prediction_futures]
+
+        return {"dates": dates, "predictions": prediction_results}
+
+    # There is no available production model
+    return None

--- a/services/orchestration/orchestration_service.py
+++ b/services/orchestration/orchestration_service.py
@@ -22,7 +22,6 @@ from ..data_processing import DataProcessingService
 from ..evaluation_service import EvaluationService
 from ..data_service import DataService
 from core.logging import logger
-from core.config import config
 
 
 class OrchestrationService(BaseService):
@@ -143,8 +142,8 @@ class OrchestrationService(BaseService):
                 return format_prediction_response(
                     prediction=result["prediction"],
                     confidence=result["confidence"],
-                    model_type=result["model_type"],
-                    symbol=result["symbol"],
+                    model_type=model_type,
+                    symbol=symbol,
                     model_version=result["model_version"],
                     date=next_trading_day,
                 )
@@ -332,28 +331,27 @@ class OrchestrationService(BaseService):
                         confidence = predictions[i]["confidence"][0]
                         model_version = predictions[i]["model_version"]
 
-                        # Get formatted result
-                        formatted_result = format_prediction_response(
-                            prediction=prediction,
-                            confidence=confidence,
-                            model_type=model_type,
-                            symbol=symbol,
-                            model_version=model_version,
-                            date=trading_days[i],
-                        )
-
                         # Save prediction to csv
                         self.prediction_storage.save_prediction_to_csv(
                             model_type=model_type,
                             symbol=symbol,
-                            date=formatted_result["date"],
+                            date=trading_days[i],
                             prediction=prediction,
                             confidence=confidence,
                             model_version=model_version,
                         )
 
                         # Add formated prediction response to the results list
-                        results.append(formatted_result)
+                        results.append(
+                            format_prediction_response(
+                                prediction=prediction,
+                                confidence=confidence,
+                                model_type=model_type,
+                                symbol=symbol,
+                                model_version=model_version,
+                                date=trading_days[i],
+                            )
+                        )
 
                 else:
                     self.logger.info(
@@ -380,8 +378,8 @@ class OrchestrationService(BaseService):
                         format_prediction_response(
                             prediction=prediction_result["prediction"],
                             confidence=prediction_result["confidence"],
-                            model_type=prediction_result["model_type"],
-                            symbol=prediction_result["symbol"],
+                            model_type=model_type,
+                            symbol=symbol,
                             model_version=prediction_result["model_version"],
                             date=date,
                         )

--- a/services/orchestration/prediction_storage.py
+++ b/services/orchestration/prediction_storage.py
@@ -1,0 +1,135 @@
+from core.config import config
+
+from datetime import datetime
+import pandas as pd
+
+
+class PredictionStorage:
+
+    def __init__(self, logger):
+        self.base_dir = config.data.PREDICT_DATA_DIR
+        self.logger = logger
+
+    def load_prediction_csv(self, model_type: str, symbol: str, date: datetime):
+        """
+        Load prediction results from the corresponding CSV file for a specified date.
+
+        Args:
+            model_type (str): The type of model used for prediction (e.g., LSTM, Prophet).
+            symbol (str): The stock symbol being predicted.
+            date (datetime): Date associated to the prediction
+
+        Returns:
+            dict|None: The prediction results if Any, else None
+        """
+
+        # Generate the file path
+        file_path = self.base_dir / model_type / f"{symbol}_predictions.csv"
+
+        if not file_path.exists():
+            return None
+
+        # Load existing CSV
+        df = pd.read_csv(file_path)
+
+        # Convert the date to the format 'YYYY-MM-DD'
+        day = date.date().isoformat()
+
+        result = df[
+            (df["symbol"] == symbol.upper())
+            & (df["date"] == day)
+            & (df["model_type"] == model_type)
+        ]
+
+        return result.iloc[0].to_dict() if not result.empty else None
+
+    def get_existing_prediction_dates(self, model_type: str, symbol: str) -> list[str]:
+        """
+        Get a list of existing dates for which predictions have already been computed and stored
+        in the csv file.
+
+        Args:
+            model_type (str): Model type (e.g., "lstm", "prophet").
+            symbol (str): Stock symbol (e.g., "AAPL").
+
+        Returns:
+            list[str]: List of dates (in 'YYYY-MM-DD' format) that already have predictions.
+        """
+
+        # Generate the file path
+        file_path = self.base_dir / model_type / f"{symbol}_predictions.csv"
+
+        # If the CSV does not exist
+        if not file_path.exists():
+            return []
+
+        # Load existing CSV
+        df = pd.read_csv(file_path)
+
+        # Extract the unique list of dates for which predictions have been made
+        existing_dates = df["date"].unique().tolist()
+
+        return existing_dates
+
+    def save_prediction_to_csv(
+        self,
+        model_type: str,
+        symbol: str,
+        date: datetime,
+        prediction: float,
+        confidence: float,
+        model_version: str,
+    ):
+        """
+        Save the prediction results to a CSV file.
+
+        Args:
+            model_type (str): The type of model used for prediction (e.g., LSTM, Prophet).
+            symbol (str): The stock symbol being predicted.
+            date (datetime): Date associated to the prediction
+            prediction (float): The predicted value from the model.
+            confidence (float): The confidence score of the prediction.
+            model_version (str): The version of the model used.
+            file_path (str): Path to the CSV file where the results will be stored.
+        """
+
+        # Generate the file path
+        file_path = self.base_dir / model_type / f"{symbol}_predictions.csv"
+
+        # Make sure the parent directory exists
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        new_data = {
+            "symbol": symbol.upper(),
+            "date": date,
+            "model_type": model_type,
+            "prediction": prediction,
+            "confidence": confidence,
+            "model_version": model_version,
+        }
+
+        # Load existing CSV if exists
+        if file_path.exists():
+            df = pd.read_csv(file_path)
+
+            # Drop any existing row for same symbol, date, and model_type
+            df = df[
+                ~(
+                    (df["symbol"] == new_data["symbol"])
+                    & (df["date"] == new_data["date"])
+                    & (df["model_type"] == new_data["model_type"])
+                )
+            ]
+
+            # Append new row
+            df = pd.concat([df, pd.DataFrame([new_data])], ignore_index=True)
+        else:
+            df = pd.DataFrame([new_data])
+
+        # Save back
+        df = df.sort_values(by=["date"])
+        df.to_csv(file_path, index=False)
+
+        self.logger.debug(
+            f"Saved prediction result for model {model_type} for symbol {symbol} for date {date} to {file_path}"
+        )

--- a/services/orchestration/prediction_storage.py
+++ b/services/orchestration/prediction_storage.py
@@ -35,11 +35,7 @@ class PredictionStorage:
         # Convert the date to the format 'YYYY-MM-DD'
         day = date.date().isoformat()
 
-        result = df[
-            (df["symbol"] == symbol.upper())
-            & (df["date"] == day)
-            & (df["model_type"] == model_type)
-        ]
+        result = df[(df["date"] == day)]
 
         return result.iloc[0].to_dict() if not result.empty else None
 
@@ -100,9 +96,7 @@ class PredictionStorage:
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
         new_data = {
-            "symbol": symbol.upper(),
-            "date": date.isoformat(),
-            "model_type": model_type,
+            "date": date.date().isoformat(),
             "prediction": prediction,
             "confidence": confidence,
             "model_version": model_version,
@@ -113,13 +107,7 @@ class PredictionStorage:
             df = pd.read_csv(file_path)
 
             # Drop any existing row for same symbol, date, and model_type
-            df = df[
-                ~(
-                    (df["symbol"] == new_data["symbol"])
-                    & (df["date"] == new_data["date"])
-                    & (df["model_type"] == new_data["model_type"])
-                )
-            ]
+            df = df[~((df["date"] == new_data["date"]))]
 
             # Append new row
             df = pd.concat([df, pd.DataFrame([new_data])], ignore_index=True)

--- a/services/orchestration/prediction_storage.py
+++ b/services/orchestration/prediction_storage.py
@@ -101,7 +101,7 @@ class PredictionStorage:
 
         new_data = {
             "symbol": symbol.upper(),
-            "date": date,
+            "date": date.isoformat(),
             "model_type": model_type,
             "prediction": prediction,
             "confidence": confidence,

--- a/services/orchestration/tasks/data/__init__.py
+++ b/services/orchestration/tasks/data/__init__.py
@@ -1,3 +1,3 @@
-from .load import load_recent_stock_data
+from .load import load_recent_stock_data, load_historical_stock_prices_from_end_date
 from .postprocess import postprocess_data
 from .preprocess import preprocess_data

--- a/services/orchestration/tasks/data/load.py
+++ b/services/orchestration/tasks/data/load.py
@@ -1,5 +1,6 @@
 from prefect import task
 import pandas as pd
+from datetime import datetime
 
 from services import DataService
 
@@ -22,4 +23,33 @@ async def load_recent_stock_data(service: DataService, symbol: str) -> pd.DataFr
         pd.DataFrame: Stock data.
     """
     data, _ = await service.get_recent_data(symbol)
+    return data
+
+
+@task(
+    name="get_historical_stock_prices_from_end_date",
+    description="Load historical stock data for a given symbol using an end date and a "
+    + "specified number of days back, with the provided data service.",
+    retries=3,
+    retry_delay_seconds=5,
+)
+async def load_historical_stock_prices_from_end_date(
+    service: DataService, symbol: str, end_date: datetime, days_back: int
+) -> pd.DataFrame:
+    """
+    Prefect task to load historical stock data for a given symbol, ending at a specified
+    date and going back a given number of days.
+
+    Args:
+        service (DataService): Data service.
+        symbol (str): Stock ticker symbol.
+        end_date (datetime): The end date for the historical data.
+        days_back (int): The number of days to look back from the end date.
+
+    Returns:
+        pd.DataFrame: A DataFrame containing the historical stock data.
+    """
+    data, _ = await service.get_historical_stock_prices_from_end_date(
+        symbol, end_date=end_date, days_back=days_back
+    )
     return data

--- a/services/training/trainers/lstm_trainer.py
+++ b/services/training/trainers/lstm_trainer.py
@@ -1,4 +1,4 @@
-from keras import Sequential, layers, callbacks  # Replace tensorflow import
+from keras import Sequential, layers, callbacks, Input  # Replace tensorflow import
 from typing import Any, Tuple, Dict
 import numpy as np
 
@@ -22,6 +22,7 @@ class LSTMTrainer(BaseTrainer):
             history = model.fit(
                 X_train,
                 y_train,
+                shuffle=False,
                 epochs=kwargs.get("epochs", 50),
                 batch_size=kwargs.get("batch_size", 32),
                 validation_split=0.2,
@@ -43,15 +44,13 @@ class LSTMTrainer(BaseTrainer):
         """Build LSTM model architecture."""
         model = Sequential(
             [
+                Input(input_shape),
                 layers.LSTM(
                     32,
-                    kernel_initializer="glorot_uniform",
-                    recurrent_initializer="orthogonal",
                     return_sequences=False,
                 ),
                 layers.Dropout(0.2),
                 layers.Dense(1),
             ]
         )
-
         return model

--- a/services/training/trainers/lstm_trainer.py
+++ b/services/training/trainers/lstm_trainer.py
@@ -44,25 +44,12 @@ class LSTMTrainer(BaseTrainer):
         model = Sequential(
             [
                 layers.LSTM(
-                    100,
-                    return_sequences=True,
-                    input_shape=input_shape,
+                    32,
                     kernel_initializer="glorot_uniform",
                     recurrent_initializer="orthogonal",
+                    return_sequences=False,
                 ),
                 layers.Dropout(0.2),
-                layers.LSTM(
-                    50,
-                    kernel_initializer="glorot_uniform",
-                    recurrent_initializer="orthogonal",
-                ),
-                layers.Dropout(0.2),
-                layers.Dense(
-                    50, activation="relu", kernel_initializer="glorot_uniform"
-                ),
-                layers.Dense(
-                    25, activation="relu", kernel_initializer="glorot_uniform"
-                ),
                 layers.Dense(1),
             ]
         )


### PR DESCRIPTION
Fixes (partly) #55
Fixes #36
Fixes #63
Ajout d'un container pour le serveur prefect
Ajout de cache lorsqu'on veut savoir si un modèle de production existe
Changement de l'architecture du modèle LSTM pour avoir une architecture avec moins de layers pour améliorer le temps de training total (ce changement fourni aussi de meilleures prédictions sur plusieurs symbols)
Ajout du pipeline run_historical_prediction_pipeline qui permet de prédire selon une plage de dates historiques (dans le passé)
Savegarde des résultats de prédictions dans des fichiers csv

** **À noter, pour centraliser les données (db), j'ai move le folder data_processing/scalers dans le folder data/scalers** **