### PR TITLE
Fix #96, use mlflow training dates

### DIFF
--- a/services/monitoring/requirements.txt
+++ b/services/monitoring/requirements.txt
@@ -1,5 +1,6 @@
 # Monitoring requirements
 
+mlflow[boto3]==2.22.0
 numpy==1.26.4
 scipy==1.16.0
 


### PR DESCRIPTION
### Correctif logique data‐drift

- Read tags `training_data_start_date`/`training_data_end_date` (MLflow -> registry -> run)  
- Appel à `/data/stock/historical` pour la fenêtre exacte, fallback sur `LOOKBACK_PERIOD_DAYS`
